### PR TITLE
Onboarding Amplica as a validator

### DIFF
--- a/paseo-validators/active/amplica.yml
+++ b/paseo-validators/active/amplica.yml
@@ -1,0 +1,11 @@
+identity:
+  display: Amplica
+  email: sai@amplica.io
+  website: https://www.amplica.io
+  riot: @wilwade-ul:matrix.org
+
+accounts:
+  0:
+    stash: 5F1rPbVunnC2YqUWzBMrHT7tk4d9eF9THdaVg3ARFvJGeYAJ
+  1:
+    stash: 5GKfM7zXFQBndoYj5GxFMg64c2SpKDSguTo58xi6megGN5Cs


### PR DESCRIPTION
We're onboarding two paseo validators as part of the Amplica Labs network, and Amplica Labs is the primary contributing team for the Frequency parachain