### PR TITLE
Add Sik | crifferent.de to active validators

### DIFF
--- a/paseo-validators/active/sik-crifferent.yml
+++ b/paseo-validators/active/sik-crifferent.yml
@@ -1,0 +1,17 @@
+identity:
+  display: Sik | crifferent.de
+  email: simon.kraus@crifferent.de
+  website: https://crifferent.de
+  twitter: @dev0_sik
+  discord: dev0_sik
+  riot: @dev0_sik:matrix.org
+
+accounts:
+  0:
+    identity:
+      display: Sik | crifferent.de
+    stash: 5H1MgERwsj7NWejMibokz8wPrc2N5obU1G7v9MUWz5hmSydS
+  1:
+    identity:
+      display: Sik 2 | crifferent.de
+    stash: 5Fpq4Rxhu6UbAs52wHMzHmjxSVBNz2eJMiQ9n6gcj1UxQMmy


### PR DESCRIPTION
This PR adds in the two validators of Sik | crifferent.de

We are whitelisted for the operation by running BridgeHub and AssetHub system chain collators on both - Polkadot and Kusama. I am also a long-term active 1KV member in both networks.

Through the Paseo element channel I also got chosen for Paseo BridgeHub collators by Hector<B>.
For sure I'll be ready when you are 🖖 