### PR TITLE
add ExtraCoin

### DIFF
--- a/paseo-validators/active/extracoin
+++ b/paseo-validators/active/extracoin
@@ -1,0 +1,17 @@
+identity:
+  display: ExtraCoin
+  email: yaronski@protonmail.com
+  website: na
+  twitter: @yaronski
+  discord: _yrn_
+  riot: @yrn:matrix.org
+
+accounts:
+  0:
+    identity:
+      display: ExtraCoin/01
+    stash: 5EXtrLLidiQGKFMCekvH2B7E8ge3kugG7ZJugSiR7gASZBQ1
+  1:
+    identity:
+      display: ExtraCoin/02
+    stash: 5EXTRcEY1dwESChjYjDkB6N4D86UiE14YkqrQX7t2gwM7XMa


### PR DESCRIPTION
This PR is an application of two Paseo validator nodes maintained by ExtraCoin to be selected to join the active set on Paseo.

ExtraCoin is running invulnerable collators in Kusama Bridge Hub and Polkadot Collectives as per the Paseo selection criteria.

Following Paradox | ParaNodes.io's call for applications for Paseo Validators in the System Parachain Collators matrix channel.