### PR TITLE
chore: new PAS for coretime onboarding process

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The individuals involved in creating a PAS are:
 1. The author of the PAS
 2. the Paseo Governance Team (PGT) which are the signers on the sudo multisig
 
-When creating a PAS, please use the following statuses in the title of your PAS - this allows the community to see which proposals have been implemented and which are still in discussion. Please update the status with a PR. 
+When creating a PAS, please use the following statuses in the title of your PAS - this allows the community to see which proposals have been implemented and which are still in discussion. Please update the status with a PR.
 * Open: Proposed and under discussion PAS
 * Merged: Approved and merged PAS
 * Closed: Dissaproved PAS
@@ -18,7 +18,7 @@ When creating a PAS, please use the following statuses in the title of your PAS 
 - Submitting a PAS: To propose a new feature or change, start by creating a PAS document.
 - Discussion and Review: Once submitted, the community will review and discuss the proposal. Feedback and constructive criticism are encouraged to refine and improve the proposal.
 - Decision Making: Proposals will be evaluated by the Paseo governance team. Decisions will be made based on community feedback, the proposal's merit, and alignment with Paseo's objectives.
-- All PAS proposals must be public domain. See in the bottom of this document for an example copyright waiver. 
+- All PAS proposals must be public domain. See in the bottom of this document for an example copyright waiver.
 
 ## What belongs in a successful PAS?
 Each PAS should have the following parts:
@@ -34,7 +34,7 @@ Each PAS should have the following parts:
 
 ### Support Model
 - [PAS 2 - Core Support Model](https://github.com/paseo-network/paseo-action-submission/blob/main/pas/PAS-2-core-support-model.md)
-  
+
 ### PASs
 
 - [PAS 0 - Template](https://github.com/paseo-network/paseo-action-submission/blob/main/pas/PAS-0-template.md)
@@ -46,3 +46,4 @@ Each PAS should have the following parts:
 - [PAS 7 - Hardware Specs](https://github.com/paseo-network/paseo-action-submission/blob/main/pas/PAS-7-Hardware_specs.md)
 - [PAS 8 - Payouts](https://github.com/paseo-network/paseo-action-submission/blob/main/pas/PAS-8-Payouts.md)
 - [PAS 9 - Onboard Paras Slots](https://github.com/paseo-network/paseo-action-submission/blob/fix-44-pas/pas/PAS-9-Onboard-paras-slots.md)
+- [PAS 10 - Onboard Paras Coretime](./pas/PAS-10-Onboard-paras-coretime.md)

--- a/pas/PAS-10-Onboard-paras-coretime.md
+++ b/pas/PAS-10-Onboard-paras-coretime.md
@@ -1,0 +1,65 @@
+---
+PAS ID: 10
+title: Onboarding Parachains - Coretime
+status: Proposed
+author: Alejandro (@al3mart)
+created: 24-10-2024
+---
+
+## Changelog
+
+| Version | Description                      | Author    | Date       |
+|---------|----------------------------------|-----------|------------|
+| 1.0     | Initial version                  | Alejandro  | 24-10-2024 |
+
+
+## Summary
+Means to onboard a parachain to Paseo via **coretime** assignment.
+
+[- Overview section details how to obtain coretime](#overview)
+
+[- Rationale section details the expected onboarding flow](#rationale)
+
+## Abstract
+In this document users can find the steps to follow to register their parachain in Paseo.
+
+## Motivation
+Allocation of resources that imply a cost and can be accessed by obtaining tokens that are freely available to everyone and have no intrinsic value.
+
+## Specification
+### Overview
+While the registration process stays the same. A combination of `registrar.reserve` and `registrar.register` calls.
+Agile Coretime introduces new methods for users to have the relay chain finalize blocks produced by connected chains.
+
+- On demand Coretime: Allows users to place a bid to have the next produced block finalized, and only one block.
+- Bulk Coretime: Allows users to acquire a fixed duration of continuous relay chain coretime.
+
+Users can place a bid to obtain on demand coretime directly in the relay chain.
+While for obtaining bulk coretime users will need to interface with the broker, hosted in the coretime chain. The broker will offer a certain number of cores available for sale periodically. Which users can obtain and assign to their chains if they so choose, if now assigned these are also transferable.
+
+The following resources contain details on how to interact with these features:
+- Polkadot Wiki: https://wiki.polkadot.network/docs/learn-agile-coretime-index
+- W3F Educhain: https://web3educhain.xyz/
+
+
+### Rationale
+The onboarding process is bounded by the resources available in the network. Meaning that parachains that are already live and need a testbed for their users will be the priority, while trying to
+maintain a healthy ratio of teams that just need sporadic resources from Paseo.
+
+The expected flow for teams to onboard is the following:
+
+- Obtain some PAS tokens via its faucet: https://faucet.polkadot.io/
+- Reserve a ParaId and register your chain in Paseo: https://wiki.polkadot.network/docs/learn-guides-coretime-parachains#reserve-paraid
+- Obtain some coretime: https://wiki.polkadot.network/docs/learn-guides-coretime-parachains
+
+If a chain is being migrated from a different testing environment or it is running in production and needs to use Paseo, contact the team, who can help you with the registration process.
+
+Users might find that both the deposists needed to register a chain and the price of bulk coretime are higher than what [the faucet](https://faucet.polkadot.io/) can provide in a regular way to its users.
+If that is a blocker for your onboarding, please, contact the team at:
+
+- https://matrix.to/#/#paseo-testnet-support:parity.io
+- https://github.com/paseo-network/support/issues
+
+
+## Copyright
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).

--- a/pas/PAS-10-Onboard-paras-coretime.md
+++ b/pas/PAS-10-Onboard-paras-coretime.md
@@ -41,6 +41,9 @@ The following resources contain details on how to interact with these features:
 - Polkadot Wiki: https://wiki.polkadot.network/docs/learn-agile-coretime-index
 - W3F Educhain: https://web3educhain.xyz/
 
+Ecosystem applications featuring coretime management:
+- RegionX: https://app.regionx.tech/?network=paseo
+
 
 ### Rationale
 The onboarding process is bounded by the resources available in the network. Meaning that parachains that are already live and need a testbed for their users will be the priority, while trying to

--- a/pas/PAS-10-Onboard-paras-coretime.md
+++ b/pas/PAS-10-Onboard-paras-coretime.md
@@ -20,7 +20,7 @@ Means to onboard a parachain to Paseo via **coretime** assignment.
 
 [- Rationale section details the expected onboarding flow](#rationale)
 
-[- Fast forward a onboarding as detailed in the support section](#support)
+[- Fast forward an onboarding as detailed in the support section](#support)
 
 ## Abstract
 In this document users can find the steps to follow to register their parachain in Paseo.

--- a/pas/PAS-10-Onboard-paras-coretime.md
+++ b/pas/PAS-10-Onboard-paras-coretime.md
@@ -63,7 +63,7 @@ Note: If a chain is being migrated from a different testing environment or it is
 
 ### Support
 
-- If there are no cores available or any other issue is faced, please escalate the issue on the same parachain onboarding, please contact the team at:
+- If there are no cores available or any other issue is faced, please escalate the issue on the same parachain onboarding or/and contact the team at:
 
 - https://matrix.to/#/#paseo-testnet-support:parity.io
 

--- a/pas/PAS-10-Onboard-paras-coretime.md
+++ b/pas/PAS-10-Onboard-paras-coretime.md
@@ -20,6 +20,8 @@ Means to onboard a parachain to Paseo via **coretime** assignment.
 
 [- Rationale section details the expected onboarding flow](#rationale)
 
+[- Fast forward a onboarding as detailed in the support section](#support)
+
 ## Abstract
 In this document users can find the steps to follow to register their parachain in Paseo.
 
@@ -56,6 +58,8 @@ The expected flow for teams to onboard is the following:
 - Obtain some coretime: https://wiki.polkadot.network/docs/learn-guides-coretime-parachains
 
 If a chain is being migrated from a different testing environment or it is running in production and needs to use Paseo, contact the team, who can help you with the registration process.
+
+### Support
 
 Users might find that both the deposists needed to register a chain and the price of bulk coretime are higher than what [the faucet](https://faucet.polkadot.io/) can provide in a regular way to its users.
 If that is a blocker for your onboarding, please, contact the team at:

--- a/pas/PAS-10-Onboard-paras-coretime.md
+++ b/pas/PAS-10-Onboard-paras-coretime.md
@@ -53,6 +53,8 @@ maintain a healthy ratio of teams that just need sporadic resources from Paseo.
 
 The expected flow for teams to onboard is the following:
 
+> The faucet might not be able to cover the onboarding cost (registration cost + coretime cost). If this affects you, please refer to [support section](#support).
+
 - Obtain some PAS tokens via its faucet: https://faucet.polkadot.io/
 - Reserve a ParaId and register your chain in Paseo: https://wiki.polkadot.network/docs/learn-guides-coretime-parachains#reserve-paraid
 - Obtain some coretime: https://wiki.polkadot.network/docs/learn-guides-coretime-parachains

--- a/pas/PAS-2-core-support-model.md
+++ b/pas/PAS-2-core-support-model.md
@@ -11,7 +11,7 @@ created: 23-02-2024
 | Version | Description                      | Author    | Date       |
 |---------|----------------------------------|-----------|------------|
 | 1.0     | Initial version                  | Edu Clerici  | 23-02-2024 |
-| 1.1     | ...                              |              |            |
+| 1.1     | Coretime update                  |  @al3mart   | 24-10-2024  |
 
 
 
@@ -23,9 +23,9 @@ The purpose of operating and maintaining the Paseo testnet is to cater to the ne
 - API Builders
 - Validators
 - Custodians
-  
+
 ## Abstract
-A short description of the proposed change, this should clearly describe the proposed change that will happen if this PAS is passed rather than why it should be done or the detail behind how to complete the changes. 
+A short description of the proposed change, this should clearly describe the proposed change that will happen if this PAS is passed rather than why it should be done or the detail behind how to complete the changes.
 
 
 ## Documentation
@@ -80,10 +80,10 @@ Support tasks that are within the scope:
 - Top up balances for sovereign accounts
 - XCM HRMP Channels Management for System Chains: Handling cross-consensus message passing channels for any Paseo System chain.
 - XCM Debugging for Parachain Support: Troubleshooting and supporting parachain-related issues from the relay chain or system chain perspective.
-- Parachain Slot Assignment: Managing the allocation of slots to parachains.
+- Parachain Slot Assignment: Managing the allocation of slots to parachains, if applicable.
 - Benchmarking : Recalculate weights for every Runtime upgrade, taking into account different hardware configurations from Polkadot.
 - Building Deterministic Runtime Artifacts: Ensuring the runtime is predictable and repeatable.
-- Coretime: Lead migration from parachain slots into coretime sales. Also once we have more details about coretime, a proper process for handling core assigments will be put in place.
+- Coretime: Lead migration from parachain slots into coretime sales. Assign tasks to cores if needed to maintain the finalization of the chains connected to Paseo.
 
 Support tasks that are **not** in the scope:
 - Analyze parachain failed storage migrations.
@@ -106,7 +106,7 @@ The workflow to acknowledge and resolve support tickets within specified time fr
 - Support Ticket Handling
   - **Acknowledgment** : Within 24 hours.
   - **Resolution** : Mean time of 72 hours (_varies based on complexity and triage_)
- 
+
 Support tickets that are **not** in the scope for the SLA:
 - every ticket that has the "Core" label on it.
 

--- a/pas/PAS-9-Onboard-paras-slots.md
+++ b/pas/PAS-9-Onboard-paras-slots.md
@@ -11,8 +11,15 @@ created: 27-02-2024
 | Version | Description                      | Author    | Date       |
 |---------|----------------------------------|-----------|------------|
 | 1.0     | Initial version                  | @al3mart  | 12-03-2024 |
+| 2.0     | Deprecation                  | @al3mart  | 24-10-2024 |
+
+## Deprecation
+
+**With the migration to coretime, the way cores can be obtained changes. Effectively deprecating the process in this document.
+Please, refer to [PAS#10](./PAS-10-Onboard-paras-coretime.md) for the up to date information.**
 
 ## Summary
+
 Means to onboard a parachain to Paseo via **leases and slot assignment**.
 This PAS is to be deprecated once parachain scheduling via coretime is deployed in Paseo.
 
@@ -27,7 +34,7 @@ At the moment of writing there is no way a user without access to root origin ca
 ## Specification
 ### Overview
 
-Users can do a regular registration via dispatching the extrinsics `registrar.reserve` to reserve a `ParaId` and `registrar.register` to submit their code and state. 
+Users can do a regular registration via dispatching the extrinsics `registrar.reserve` to reserve a `ParaId` and `registrar.register` to submit their code and state.
 To obtain a slot for your parachain, aka upgrading your parathread to a parachain, users can log an issue in [Paseo's support repository](https://github.com/paseo-network/support) for that, they can use the custom issue template in https://github.com/paseo-network/support/issues/new/choose.
 This might be handy in case the root action is needed in the relay chain, for instance.
 Users can always open an issue in case their desired `ParaId` is < `4000`.


### PR DESCRIPTION
Include PAS-10 detailing the process for new chains connecting to Paseo to obtain coretime.
Deprecates PAS-9 
Amends other documents referring to leases and slot allocation.