### PR TITLE
Include one-t web dashboard as an additional service to Paseo

### DIFF
--- a/additional-services/active/turboflakes.yml
+++ b/additional-services/active/turboflakes.yml
@@ -1,0 +1,7 @@
+serviceName: ONE-T Web dashboard
+description: Monitor and explorer for Paseo Network to evaluate validator performances and network status
+provider: turboflakes.io
+email: support@turboflakes.io
+matrix: @turboflakes:matrix.org
+costPerQuarter: $450
+startDate: 01/06/2024


### PR DESCRIPTION
Hello Team,

This PR is meant to include ONE-T Web dashboard as an additional service for Paseo