### PR TITLE
chore: whitelist Parity's nominator stash

### DIFF
--- a/whitelists/whitelist.yml
+++ b/whitelists/whitelist.yml
@@ -455,3 +455,5 @@ whitelist:
     address: 13QtuXhb8SecJacGUVHgj4fTkcp1dRBxGcXedpdNdVCjQ1qt
   - name: Parity PDP
     address: 13ihzQgscAofUtquwmsymSPKtoxwYvrpMxtFRnqg49ykdfzn
+  - name: Parity nominator stash
+    address: 13maujzA7BnLGiH5VTtE58FQv5nTNHiBTxyVv2uzRKKLZSV7


### PR DESCRIPTION
Add Parity's nominator stash to the whitelist.
This account will be used to execute tests in preparation to the migration.

<!-- ClickUpRef: 869a0vv1c -->
:link: [zboto Link](https://app.clickup.com/t/869a0vv1c)