### PR TITLE
chore(whitelist): append nominator 8 to whitelist

### DIFF
--- a/whitelists/whitelist.yml
+++ b/whitelists/whitelist.yml
@@ -459,3 +459,5 @@ whitelist:
     address: 13maujzA7BnLGiH5VTtE58FQv5nTNHiBTxyVv2uzRKKLZSV7
   - name: AH_migration_parity
     address: 14iw76ZmY7BzFfBYrTrCnMyAzU5X4LY5jCFN6XuSnTYnzaTe
+  - name: Nominator 8
+    address: 1KMtookzJ1p6vXb6tRARhj8CFqMjhoibsr3y1VWy9SQHb76


### PR DESCRIPTION
The account `1KMtookzJ1p6vXb6tRARhj8CFqMjhoibsr3y1VWy9SQHb76` is one of the nominators we use. It should be added to the whitelist to reduce noise on logs regarding accounts with big bounded balances.

<!-- ClickUpRef: 869a2j45m -->
:link: [zboto Link](https://app.clickup.com/t/869a2j45m)