### PR TITLE
Add DPSTK validator info to paseo-providers

### DIFF
--- a/paseo-providers/validators/dpstk.yml
+++ b/paseo-providers/validators/dpstk.yml
@@ -1,0 +1,18 @@
+identity:
+  display: DPSTK
+  email: info@dpstk.de
+  website:
+  twitter:
+  discord:
+  riot: "@dapestake:matrix.org"
+
+accounts:
+- identity:
+    display: DPSTK - VAL01
+  stash: 12v3n3ERC9qaGvh8EMpqoqbJ9uTNFfVz5V97SgijopadQQNz
+- identity:
+    display: DPSTK - VAL02
+  stash: 12sbyyn9jmJuDNj4dN9KXG4kFuk73jNzes8iL65EkL2zF2YZ
+- identity:
+    display: DPSTK - PASEO 3
+  stash: 1jg7ZiqWG2VRJgCJdbMUmMA58oyxqoYkLKm99cDzSafdL9k


### PR DESCRIPTION
## Summary

Moves DPSTK into the new `paseo-providers/validators/` folder as part of the Paseo v2 (2026 Q3 onwards) node distribution.

Per `launch/paseo-v2-launch.md`, DPSTK runs **3 validators**. DPSTK confirmed they will reuse the same keys, so the first 3 stashes from `paseo-legacy/paseo-validators/active/dpstk.yml` are carried over verbatim:

| Validator | Stash |
|---|---|
| DPSTK - VAL01 | `12v3n3ERC9qaGvh8EMpqoqbJ9uTNFfVz5V97SgijopadQQNz` |
| DPSTK - VAL02 | `12sbyyn9jmJuDNj4dN9KXG4kFuk73jNzes8iL65EkL2zF2YZ` |
| DPSTK - PASEO 3 | `1jg7ZiqWG2VRJgCJdbMUmMA58oyxqoYkLKm99cDzSafdL9k` |

The legacy file is left untouched, matching the migration pattern used for `sik-crifferent`.