### PR TITLE
Add Polkadotters validator info to paseo-providers

### DIFF
--- a/paseo-providers/validators/polkadotters.yml
+++ b/paseo-providers/validators/polkadotters.yml
@@ -1,0 +1,15 @@
+identity:
+  display: Polkadotters
+  email: polkadotters@protonmail.com
+  website: https://polkadotters.com
+  twitter: "@Polkadotters1"
+  discord: pmensik#3434
+  riot: "@pmensik:matrix.org"
+
+accounts:
+- identity:
+    display: Polkadotters
+  stash: 12s6UMSSfE2bNxtYrJc6eeuZ7UxQnRpUzaAh1gPQrGNFnE8h
+- identity:
+    display: Polkadotters/SHRIMP
+  stash: 12owmS8Sobqxfx6KK9vk9e67FqnGpZdmxCFCRFptzZdsoujC


### PR DESCRIPTION
## Summary

Moves Polkadotters into the new `paseo-providers/validators/` folder as part of the Paseo v2 (2026 Q3 onwards) node distribution.

Per `launch/paseo-v2-launch.md`, Polkadotters runs **2 validators**. Polkadotters confirmed they will reuse the same keys, so the first 2 stashes from `paseo-legacy/paseo-validators/active/polkadotters.yml` are carried over verbatim:

| Validator | Stash |
|---|---|
| Polkadotters | `12s6UMSSfE2bNxtYrJc6eeuZ7UxQnRpUzaAh1gPQrGNFnE8h` |
| Polkadotters/SHRIMP | `12owmS8Sobqxfx6KK9vk9e67FqnGpZdmxCFCRFptzZdsoujC` |

The legacy file is left untouched, matching the migration pattern used for `dpstk` and `sik-crifferent`.