### PR TITLE
Add Staker Space validator information for Paseo V2

### DIFF
--- a/paseo-providers/validators/staker-space.yml
+++ b/paseo-providers/validators/staker-space.yml
@@ -1,0 +1,20 @@
+identity:
+  display: Staker Space
+  email: hello@staker.space
+  website: https://staker.space
+  twitter: "@StakerSpace"
+  discord: sustakerspace
+  riot: "@suley:matrix.org"
+
+accounts:
+  - identity:
+      display: Staker Space/01
+    stash: 1128LMvaKYP367kgJz5Y4bA68QgUJwLMz14nWLeS36Ts4WZU
+
+  - identity:
+      display: Staker Space/02
+    stash: 138g1op1nPsZ3mL6SdDu9KKP41pZxAm6oUA96A7AQWLAQ5gu
+
+  - identity:
+      display: Staker Space/03
+    stash: 12N3gvs6SMvQfQN9r6rr18VV6VVEp781uQy1uHNmSn9GTNts


### PR DESCRIPTION
## Summary

Moves Staker Space into the new `paseo-providers/validators/` folder as part of the Paseo v2 (2026 Q3 onwards) node distribution.

Per `launch/paseo-v2-launch.md`, Staker Space runs **3 validators**. Staker Space will reuse the same keys, so the first 3 stashes from `paseo-legacy/paseo-validators/active/staker-space.yml` are carried over verbatim:

| Validator | Stash |
|---|---|
| Staker Space/01 | `1128LMvaKYP367kgJz5Y4bA68QgUJwLMz14nWLeS36Ts4WZU` |
| Staker Space/02 | `138g1op1nPsZ3mL6SdDu9KKP41pZxAm6oUA96A7AQWLAQ5gu` |
| Staker Space/03 | `12N3gvs6SMvQfQN9r6rr18VV6VVEp781uQy1uHNmSn9GTNts` |
