### PR TITLE
Add Mile validator info to paseo-providers

### DIFF
--- a/paseo-providers/validators/mile.yml
+++ b/paseo-providers/validators/mile.yml
@@ -1,0 +1,18 @@
+identity:
+  display: Mile
+  email: mherceg@protonmail.com
+  website:
+  twitter:
+  discord:
+  riot: "@matherceg:matrix.org"
+
+accounts:
+- identity:
+    display: Mile
+  stash: 1HznmFfzmCa7XbJ6kTddy239jvYiw3xtGipQDkrwbksyHf9
+- identity:
+    display: Mile/Bravo
+  stash: 13eRz7d5JYLm8Ju1M8ENSwA8MWhHvrQn83s22DamF2Jv12v
+- identity:
+    display: Mile/Charlie
+  stash: 15g6GHqsG5mSqMafx9KyGZiHMCLU5oqBwv3nUPQTAD7SFUic


### PR DESCRIPTION
Moves Mile into the new `paseo-providers/validators/` folder as part of the Paseo v2 (2026 Q3 onwards) node distribution.

Per `launch/paseo-v2-launch.md`, Mile runs 3 validators. Mile confirmed they will reuse the same keys, so the first 3 stashes from `paseo-legacy/paseo-validators/active/mile.yml `are carried over verbatim:

Validator | Stash
-- | --
Mile | 1HznmFfzmCa7XbJ6kTddy239jvYiw3xtGipQDkrwbksyHf9
Mile/Bravo | 13eRz7d5JYLm8Ju1M8ENSwA8MWhHvrQn83s22DamF2Jv12v
Mile/Charlie | 15g6GHqsG5mSqMafx9KyGZiHMCLU5oqBwv3nUPQTAD7SFUic